### PR TITLE
Fix username links

### DIFF
--- a/administration/organizers.md
+++ b/administration/organizers.md
@@ -1,8 +1,8 @@
 # Organizers of events
 
 ## Organizers 
-- Robbie Holmes (@robbiethegeek)
-- Dan Paz-Soldan (@danpaz)
+- Robbie Holmes ([@robbiethegeek](https://github.com/robbiethegeek))
+- Dan Paz-Soldan ([@danpaz](https://github.com/danpaz))
 
 ## Event Host(s)
-- Jack Koppa (@jackkoppa)
+- Jack Koppa ([@jackkoppa](https://github.com/jackkoppa))


### PR DESCRIPTION
Per https://github.com/github/markup/issues/1075, seems unlikely GitHub will auto-link @ mentions